### PR TITLE
chore(docker): purge linux-libc-dev package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,10 @@ COPY gunicorn.ini ./
 
 COPY .git ./.git
 
+USER root
+RUN apt purge -y linux-libc-dev
+USER oim
+
 EXPOSE 8080
 HEALTHCHECK --interval=1m --timeout=5s --start-period=10s --retries=3 CMD ["wget", "-q", "-O", "-", "http://localhost:8080/"]
 CMD ["/startup.sh"]


### PR DESCRIPTION
Remove unneeded linux-libc-dev package from the container image.